### PR TITLE
Add support for the Linux flatpak version of Hytale in build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ group = "com.example"
 version = "0.1.0"
 val javaVersion = 25
 
-val appData = System.getenv("APPDATA") ?: ""
+val appData = System.getenv("APPDATA") ?: (System.getenv("HOME") + "/.var/app/com.hypixel.HytaleLauncher/data")
 val hytaleAssets = file("$appData/Hytale/install/release/package/game/latest/Assets.zip")
 
 


### PR DESCRIPTION
On Linux there is no APPDATA folder and Asset.zip is located in an other path, this patch will use the appropriate path on Linux.