### PR TITLE
Appdata paths

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ tasks.named<ProcessResources>("processResources") {
 }
 
 hytale {
-
+    gameDir = "$appData/Hytale"
 }
 
 tasks.withType<Jar> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,25 @@ group = "com.example"
 version = "0.1.0"
 val javaVersion = 25
 
-val appData = System.getenv("APPDATA") ?: (System.getenv("HOME") + "/.var/app/com.hypixel.HytaleLauncher/data")
-val hytaleAssets = file("$appData/Hytale/install/release/package/game/latest/Assets.zip")
+val os = System.getProperty("os.name").lowercase()
 
+val appData = when {
+    os.contains("win") ->
+        System.getenv("APPDATA")
+
+    os.contains("mac") || os.contains("darwin") ->
+        "${System.getenv("HOME")}/Library/Application Support"
+
+    os.contains("linux") ->
+        System.getenv("XDG_DATA_HOME")
+            ?: "${System.getenv("HOME")}/.local/share"
+
+    else -> error("Unsupported OS")
+}
+
+val hytaleAssets = file(
+    "$appData/Hytale/install/release/package/game/latest/Assets.zip"
+)
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ group = "com.example"
 version = "0.1.0"
 val javaVersion = 25
 
+val home = System.getenv("HOME")
 val os = System.getProperty("os.name").lowercase()
 
 val appData = when {
@@ -14,11 +15,18 @@ val appData = when {
         System.getenv("APPDATA")
 
     os.contains("mac") || os.contains("darwin") ->
-        "${System.getenv("HOME")}/Library/Application Support"
+        "$home/Library/Application Support"
 
-    os.contains("linux") ->
-        System.getenv("XDG_DATA_HOME")
-            ?: "${System.getenv("HOME")}/.local/share"
+    os.contains("linux") -> {
+        val flatpakPath = "$home/.var/app/com.hypixel.HytaleLauncher/data"
+        when {
+            File(flatpakPath).exists() -> flatpakPath
+            System.getenv("XDG_DATA_HOME") != null ->
+                System.getenv("XDG_DATA_HOME")
+            else ->
+                "$home/.local/share"
+        }
+    }
 
     else -> error("Unsupported OS")
 }


### PR DESCRIPTION
Set correct build paths for Windows, Mac, Linux and flatpaks. Kinda a duplicate of #3 but with more support.

Also fixed an issue where plugin "hytale-mod" does not use the correct Linux path, see in commit 70eab92.