### PR TITLE
Add Kotlin build support to Gradle FIle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `maven-publish`
     id("hytale-mod") version "0.+"
+    kotlin("jvm") version "2.3.0"
 }
 
 group = "com.example"
@@ -17,6 +18,7 @@ repositories {
 dependencies {
     compileOnly(libs.jetbrains.annotations)
     compileOnly(libs.jspecify)
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 }
 
 hytale {


### PR DESCRIPTION
I took the kotlin specific stuff from https://github.com/Zablas/Hytale-PluginStarter-Kotlin and added it into the gradle files to allow for Kotlin to be built with this plugin template